### PR TITLE
Delaying npm installation check

### DIFF
--- a/Kwf/ComposerExtraAssets/Plugin.php
+++ b/Kwf/ComposerExtraAssets/Plugin.php
@@ -17,10 +17,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $this->composer = $composer;
 
         $this->io = $io;
-        exec('npm --version 2>&1', $out, $retVar);
-        if ($retVar) {
-            throw new \Exception("Can't find npm, not in path");
-        }
     }
 
     public static function getSubscribedEvents()
@@ -37,6 +33,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
     public function onPostUpdateInstall(Event $event)
     {
+        exec('npm --version 2>&1', $out, $retVar);
+        if ($retVar) {
+            throw new \Exception("Can't find npm, not in path");
+        }
+
         $this->_installNpm('.', $this->composer->getPackage(), $event->isDevMode());
         $packages = $this->composer->getRepositoryManager()->getLocalRepository()->getCanonicalPackages();
         foreach($packages as $package){


### PR DESCRIPTION
This is directly related to #4 .

In order to add the opportunity to install npm by other plugins (namely mouf/nodejs-installer), I moved the check on npm installation from the `activate` method to the `onPostUpdateInstall` method.

This is my test `composer.json` file:

```
{
    "require": {
        "koala-framework/composer-extra-assets": "dev-master",
        "mouf/nodejs-installer": "~1.0",
        "composer/composer": "*"
    },
    "autoload": {
        "psr-0": {"Test": ["src/", "src-dev/", "tests/"]}
    },
    "minimum-stability": "dev",
    "extra": {
        "require-npm": {
            "grunt": "0.4.*"
        },
        "require-bower": {
            "jquery": "*"
        },
        "require-dev-bower": {
            "qunit": "*"
        }
    }
}
```

With the changes in this PR, this works nicely, even on a machine with no nodejs installed.

Note: I updated the "mouf/nodejs-installer" so that it prepends *vendor/bin* to the PATH. Therefore, when *composer-extra-assets* is triggered, it loads node / npm from the *vendor/bin* directory automatically.