### PR TITLE
Automatic detection of NPM binaries

### DIFF
--- a/Kwf/ComposerExtraAssets/LinkWriter.php
+++ b/Kwf/ComposerExtraAssets/LinkWriter.php
@@ -57,7 +57,7 @@ DIR=\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" && pwd )
     
 export PATH=\$DIR:\$PATH
     
-%s $@
+\$DIR/%s $@
 EOT;
     	$completePath = $this->binaryDir.DIRECTORY_SEPARATOR.$fileName;
     	file_put_contents($completePath, sprintf($fileContent, $relativePathToTarget));

--- a/Kwf/ComposerExtraAssets/LinkWriter.php
+++ b/Kwf/ComposerExtraAssets/LinkWriter.php
@@ -1,0 +1,101 @@
+<?php
+namespace Kwf\ComposerExtraAssets;
+
+use Version\Constraint;
+
+/**
+ * Class in charge of writing links in the bin directory. 
+ */
+class LinkWriter
+{
+	private $binaryDir;
+	
+	/**
+	 * 
+	 * @param string $binaryDir The path to the binary directory.
+	 */
+	public function __construct($binaryDir) {
+		$this->binaryDir = $binaryDir;
+	}
+	
+    /**
+     * Writes a shortcut to the target link in the vendor directory.
+     *
+	 * @param string $target
+	 */
+    public function writeLink($target)
+    {
+    	$fileName = basename($target);
+    	$realTarget = realpath($target);
+    	$relativePathToTarget = $this->makePathRelative(dirname($realTarget), $this->binaryDir).basename($realTarget);
+    	
+    	// If Windows cmd link
+    	if (pathinfo($target, PATHINFO_EXTENSION) == "cmd") {
+    		$this->writeWindows($fileName, $relativePathToTarget);
+    	} else {
+    		$this->writeBash($fileName, $relativePathToTarget);
+    	}
+    }
+    
+    private function writeWindows($fileName, $relativePathToTarget) {
+    	$fileContent = <<<EOT
+@ECHO OFF
+    	
+SET PATH=%%~dp0;%%PATH%%
+    	
+%%~dp0%s %%*
+EOT;
+    	$completePath = $this->binaryDir.DIRECTORY_SEPARATOR.$fileName;
+    	file_put_contents($completePath, sprintf($fileContent, str_replace('/', '\\', $relativePathToTarget)));
+    }
+
+    private function writeBash($fileName, $relativePathToTarget) {
+    	$fileContent = <<<EOT
+#!/bin/bash
+
+DIR=\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" && pwd )
+    
+export PATH=\$DIR:\$PATH
+    
+%s $@
+EOT;
+    	$completePath = $this->binaryDir.DIRECTORY_SEPARATOR.$fileName;
+    	file_put_contents($completePath, sprintf($fileContent, $relativePathToTarget));
+    	chmod($completePath, 0755);
+    }
+    
+    /**
+     * Given an existing path, convert it to a path relative to a given starting path.
+     * Function borrowed to Symfony's Filesystem. Thanks pals.
+     *
+     * @param string $endPath   Absolute path of target
+     * @param string $startPath Absolute path where traversal begins
+     *
+     * @return string Path of target relative to starting path
+     */
+    private function makePathRelative($endPath, $startPath)
+    {
+    	// Normalize separators on Windows
+    	if ('\\' === DIRECTORY_SEPARATOR) {
+    		$endPath = strtr($endPath, '\\', '/');
+    		$startPath = strtr($startPath, '\\', '/');
+    	}
+    	// Split the paths into arrays
+    	$startPathArr = explode('/', trim($startPath, '/'));
+    	$endPathArr = explode('/', trim($endPath, '/'));
+    	// Find for which directory the common path stops
+    	$index = 0;
+    	while (isset($startPathArr[$index]) && isset($endPathArr[$index]) && $startPathArr[$index] === $endPathArr[$index]) {
+    		$index++;
+    	}
+    	// Determine how deep the start path is relative to the common path (ie, "web/bundles" = 2 levels)
+    	$depth = count($startPathArr) - $index;
+    	// Repeated "../" for each level need to reach the common path
+    	$traverser = str_repeat('../', $depth);
+    	$endPathRemainder = implode('/', array_slice($endPathArr, $index));
+    	// Construct $endPath from traversing to the common path, then to the remaining $endPath
+    	$relativePath = $traverser.('' !== $endPathRemainder ? $endPathRemainder.'/' : '');
+    	return '' === $relativePath ? './' : $relativePath;
+    }
+    
+}

--- a/Kwf/ComposerExtraAssets/LinkWriter.php
+++ b/Kwf/ComposerExtraAssets/LinkWriter.php
@@ -1,69 +1,71 @@
 <?php
 namespace Kwf\ComposerExtraAssets;
 
-use Version\Constraint;
 
 /**
- * Class in charge of writing links in the bin directory. 
+ * Class in charge of writing links in the bin directory.
  */
 class LinkWriter
 {
-	private $binaryDir;
-	
-	/**
-	 * 
-	 * @param string $binaryDir The path to the binary directory.
-	 */
-	public function __construct($binaryDir) {
-		$this->binaryDir = $binaryDir;
-	}
-	
+    private $binaryDir;
+
+    /**
+     *
+     * @param string $binaryDir The path to the binary directory.
+     */
+    public function __construct($binaryDir)
+    {
+        $this->binaryDir = $binaryDir;
+    }
+
     /**
      * Writes a shortcut to the target link in the vendor directory.
      *
-	 * @param string $target
-	 */
+     * @param string $target
+     */
     public function writeLink($target)
     {
-    	$fileName = basename($target);
-    	$realTarget = realpath($target);
-    	$relativePathToTarget = $this->makePathRelative(dirname($realTarget), $this->binaryDir).basename($realTarget);
-    	
-    	// If Windows cmd link
-    	if (pathinfo($target, PATHINFO_EXTENSION) == "cmd") {
-    		$this->writeWindows($fileName, $relativePathToTarget);
-    	} else {
-    		$this->writeBash($fileName, $relativePathToTarget);
-    	}
-    }
-    
-    private function writeWindows($fileName, $relativePathToTarget) {
-    	$fileContent = <<<EOT
-@ECHO OFF
-    	
-SET PATH=%%~dp0;%%PATH%%
-    	
-%%~dp0%s %%*
-EOT;
-    	$completePath = $this->binaryDir.DIRECTORY_SEPARATOR.$fileName;
-    	file_put_contents($completePath, sprintf($fileContent, str_replace('/', '\\', $relativePathToTarget)));
+        $fileName = basename($target);
+        $realTarget = realpath($target);
+        $relativePathToTarget = $this->makePathRelative(dirname($realTarget), $this->binaryDir).basename($realTarget);
+
+        // If Windows cmd link
+        if (pathinfo($target, PATHINFO_EXTENSION) == "cmd") {
+            $this->writeWindows($fileName, $relativePathToTarget);
+        } else {
+            $this->writeBash($fileName, $relativePathToTarget);
+        }
     }
 
-    private function writeBash($fileName, $relativePathToTarget) {
-    	$fileContent = <<<EOT
+    private function writeWindows($fileName, $relativePathToTarget)
+    {
+        $fileContent = <<<EOT
+@ECHO OFF
+
+SET PATH=%%~dp0;%%PATH%%
+
+%%~dp0%s %%*
+EOT;
+        $completePath = $this->binaryDir.DIRECTORY_SEPARATOR.$fileName;
+        file_put_contents($completePath, sprintf($fileContent, str_replace('/', '\\', $relativePathToTarget)));
+    }
+
+    private function writeBash($fileName, $relativePathToTarget)
+    {
+        $fileContent = <<<EOT
 #!/bin/bash
 
 DIR=\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" && pwd )
-    
+
 export PATH=\$DIR:\$PATH
-    
+
 \$DIR/%s $@
 EOT;
-    	$completePath = $this->binaryDir.DIRECTORY_SEPARATOR.$fileName;
-    	file_put_contents($completePath, sprintf($fileContent, $relativePathToTarget));
-    	chmod($completePath, 0755);
+        $completePath = $this->binaryDir.DIRECTORY_SEPARATOR.$fileName;
+        file_put_contents($completePath, sprintf($fileContent, $relativePathToTarget));
+        chmod($completePath, 0755);
     }
-    
+
     /**
      * Given an existing path, convert it to a path relative to a given starting path.
      * Function borrowed to Symfony's Filesystem. Thanks pals.
@@ -75,27 +77,27 @@ EOT;
      */
     private function makePathRelative($endPath, $startPath)
     {
-    	// Normalize separators on Windows
-    	if ('\\' === DIRECTORY_SEPARATOR) {
-    		$endPath = strtr($endPath, '\\', '/');
-    		$startPath = strtr($startPath, '\\', '/');
-    	}
-    	// Split the paths into arrays
-    	$startPathArr = explode('/', trim($startPath, '/'));
-    	$endPathArr = explode('/', trim($endPath, '/'));
-    	// Find for which directory the common path stops
-    	$index = 0;
-    	while (isset($startPathArr[$index]) && isset($endPathArr[$index]) && $startPathArr[$index] === $endPathArr[$index]) {
-    		$index++;
-    	}
-    	// Determine how deep the start path is relative to the common path (ie, "web/bundles" = 2 levels)
-    	$depth = count($startPathArr) - $index;
-    	// Repeated "../" for each level need to reach the common path
-    	$traverser = str_repeat('../', $depth);
-    	$endPathRemainder = implode('/', array_slice($endPathArr, $index));
-    	// Construct $endPath from traversing to the common path, then to the remaining $endPath
-    	$relativePath = $traverser.('' !== $endPathRemainder ? $endPathRemainder.'/' : '');
-    	return '' === $relativePath ? './' : $relativePath;
+        // Normalize separators on Windows
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $endPath = strtr($endPath, '\\', '/');
+            $startPath = strtr($startPath, '\\', '/');
+        }
+        // Split the paths into arrays
+        $startPathArr = explode('/', trim($startPath, '/'));
+        $endPathArr = explode('/', trim($endPath, '/'));
+        // Find for which directory the common path stops
+        $index = 0;
+        while (isset($startPathArr[$index]) && isset($endPathArr[$index]) && $startPathArr[$index] === $endPathArr[$index]) {
+            $index++;
+        }
+        // Determine how deep the start path is relative to the common path (ie, "web/bundles" = 2 levels)
+        $depth = count($startPathArr) - $index;
+        // Repeated "../" for each level need to reach the common path
+        $traverser = str_repeat('../', $depth);
+        $endPathRemainder = implode('/', array_slice($endPathArr, $index));
+        // Construct $endPath from traversing to the common path, then to the remaining $endPath
+        $relativePath = $traverser.('' !== $endPathRemainder ? $endPathRemainder.'/' : '');
+
+        return '' === $relativePath ? './' : $relativePath;
     }
-    
 }

--- a/Kwf/ComposerExtraAssets/Plugin.php
+++ b/Kwf/ComposerExtraAssets/Plugin.php
@@ -202,22 +202,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         
         $binaries = glob("node_modules/.bin/*");
         foreach ($binaries as $binary) {
-        	$linkWriter->writeLink($binary);
-            /*$binDir = $this->composer->getConfig()->get('bin-dir');
-
-            
-            // TODO: symlink does not work on Windows
-            // PLUS: script tries to find node in the path, and we are not sure to have it there!
-            // We need to write scripts instead!!!
-            $realBinary = realpath($binary);
-            chdir($binDir);
-            if (file_exists(basename($binary))) {
-                unlink(basename($binary));
-            }
-            $result = symlink($this->makePathRelative(dirname($realBinary), $binDir).basename($realBinary), basename($binary));
-			if ($result == false) {
-				throw new \Exception(error_get_last());
-			}*/
+            $linkWriter->writeLink($binary);
         }
         
         chdir($prevCwd);

--- a/Kwf/ComposerExtraAssets/Plugin.php
+++ b/Kwf/ComposerExtraAssets/Plugin.php
@@ -198,52 +198,29 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         unlink('package.json');
 
         // Let's link binaries, if any:
+        $linkWriter = new LinkWriter($this->composer->getConfig()->get('bin-dir'));
+        
         $binaries = glob("node_modules/.bin/*");
         foreach ($binaries as $binary) {
-            $binDir = $this->composer->getConfig()->get('bin-dir');
+        	$linkWriter->writeLink($binary);
+            /*$binDir = $this->composer->getConfig()->get('bin-dir');
 
+            
+            // TODO: symlink does not work on Windows
+            // PLUS: script tries to find node in the path, and we are not sure to have it there!
+            // We need to write scripts instead!!!
             $realBinary = realpath($binary);
             chdir($binDir);
             if (file_exists(basename($binary))) {
                 unlink(basename($binary));
             }
-            symlink($this->makePathRelative(dirname($realBinary), $binDir).basename($realBinary), basename($binary));
+            $result = symlink($this->makePathRelative(dirname($realBinary), $binDir).basename($realBinary), basename($binary));
+			if ($result == false) {
+				throw new \Exception(error_get_last());
+			}*/
         }
         
         chdir($prevCwd);
     }
 
-    /**
-     * Given an existing path, convert it to a path relative to a given starting path.
-     * Function borrowed to Symfony's Filesystem. Thanks pals.
-     *
-     * @param string $endPath   Absolute path of target
-     * @param string $startPath Absolute path where traversal begins
-     *
-     * @return string Path of target relative to starting path
-     */
-    private function makePathRelative($endPath, $startPath)
-    {
-        // Normalize separators on Windows
-        if ('\\' === DIRECTORY_SEPARATOR) {
-            $endPath = strtr($endPath, '\\', '/');
-            $startPath = strtr($startPath, '\\', '/');
-        }
-        // Split the paths into arrays
-        $startPathArr = explode('/', trim($startPath, '/'));
-        $endPathArr = explode('/', trim($endPath, '/'));
-        // Find for which directory the common path stops
-        $index = 0;
-        while (isset($startPathArr[$index]) && isset($endPathArr[$index]) && $startPathArr[$index] === $endPathArr[$index]) {
-            $index++;
-        }
-        // Determine how deep the start path is relative to the common path (ie, "web/bundles" = 2 levels)
-        $depth = count($startPathArr) - $index;
-        // Repeated "../" for each level need to reach the common path
-        $traverser = str_repeat('../', $depth);
-        $endPathRemainder = implode('/', array_slice($endPathArr, $index));
-        // Construct $endPath from traversing to the common path, then to the remaining $endPath
-        $relativePath = $traverser.('' !== $endPathRemainder ? $endPathRemainder.'/' : '');
-        return '' === $relativePath ? './' : $relativePath;
-    }
 }

--- a/Kwf/ComposerExtraAssets/Plugin.php
+++ b/Kwf/ComposerExtraAssets/Plugin.php
@@ -158,7 +158,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         }
 
         if ($dependencies) {
-            $this->_installNpmDependencies($path, $dependencies);
+            if ($path == '.' || (isset($extra['expose-npm-binaries']) && $extra['expose-npm-binaries'] == true)) {
+                $this->_installNpmDependencies($path, $dependencies);
+            }
         }
     }
 

--- a/Kwf/ComposerExtraAssets/Plugin.php
+++ b/Kwf/ComposerExtraAssets/Plugin.php
@@ -196,7 +196,54 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         }
 
         unlink('package.json');
+
+        // Let's link binaries, if any:
+        $binaries = glob("node_modules/.bin/*");
+        foreach ($binaries as $binary) {
+            $binDir = $this->composer->getConfig()->get('bin-dir');
+
+            $realBinary = realpath($binary);
+            chdir($binDir);
+            if (file_exists(basename($binary))) {
+                unlink(basename($binary));
+            }
+            symlink($this->makePathRelative(dirname($realBinary), $binDir).basename($realBinary), basename($binary));
+        }
+        
         chdir($prevCwd);
     }
-}
 
+    /**
+     * Given an existing path, convert it to a path relative to a given starting path.
+     * Function borrowed to Symfony's Filesystem. Thanks pals.
+     *
+     * @param string $endPath   Absolute path of target
+     * @param string $startPath Absolute path where traversal begins
+     *
+     * @return string Path of target relative to starting path
+     */
+    private function makePathRelative($endPath, $startPath)
+    {
+        // Normalize separators on Windows
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $endPath = strtr($endPath, '\\', '/');
+            $startPath = strtr($startPath, '\\', '/');
+        }
+        // Split the paths into arrays
+        $startPathArr = explode('/', trim($startPath, '/'));
+        $endPathArr = explode('/', trim($endPath, '/'));
+        // Find for which directory the common path stops
+        $index = 0;
+        while (isset($startPathArr[$index]) && isset($endPathArr[$index]) && $startPathArr[$index] === $endPathArr[$index]) {
+            $index++;
+        }
+        // Determine how deep the start path is relative to the common path (ie, "web/bundles" = 2 levels)
+        $depth = count($startPathArr) - $index;
+        // Repeated "../" for each level need to reach the common path
+        $traverser = str_repeat('../', $depth);
+        $endPathRemainder = implode('/', array_slice($endPathArr, $index));
+        // Construct $endPath from traversing to the common path, then to the remaining $endPath
+        $relativePath = $traverser.('' !== $endPathRemainder ? $endPathRemainder.'/' : '');
+        return '' === $relativePath ? './' : $relativePath;
+    }
+}

--- a/Kwf/ComposerExtraAssets/Plugin.php
+++ b/Kwf/ComposerExtraAssets/Plugin.php
@@ -34,14 +34,24 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
     public function onPostUpdateInstall(Event $event)
     {
-        $this->_installNpm('.', $this->composer->getPackage(), $event->isDevMode());
         $packages = $this->composer->getRepositoryManager()->getLocalRepository()->getCanonicalPackages();
+        $mergedNpmPackages = array();
+        // NPM install for dependencies that are not exposed.
         foreach ($packages as $package){
             if ($package instanceof \Composer\Package\CompletePackage) {
-
-                $this->_installNpm($this->composer->getConfig()->get('vendor-dir') . '/' .$package->getName(), $package, false);
+                $extra = $package->getExtra();
+                if (!isset($extra['expose-npm-packages']) || $extra['expose-npm-packages'] != true) {
+                    $this->_installNpm($this->composer->getConfig()->get('vendor-dir') . '/' .$package->getName(), $package, false, array());
+                } else {
+                    $mergedNpmPackages[] = $package;
+                }
             }
         }
+
+        // NPM install for dependencies that are exposed on the root package.
+        $this->_installNpm('.', $this->composer->getPackage(), $event->isDevMode(), $mergedNpmPackages);
+
+        $this->_createNpmBinaries();
 
         $requireBower = array();
 
@@ -141,27 +151,52 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         }
     }
 
-    private function _installNpm($path, $package, $devMode)
+    private function _installNpm($path, $package, $devMode, array $mergedPackages)
     {
         $dependencies = array();
 
         $extra = $package->getExtra();
         if ($devMode) {
             if (isset($extra['require-dev-npm']) && count($extra['require-dev-npm'])) {
-                $dependencies = array_merge($dependencies, $extra['require-dev-npm']);
+                $dependencies = $this->mergeNpmVersions($dependencies, $extra['require-dev-npm']);
             }
 
         }
 
         if (isset($extra['require-npm']) && count($extra['require-npm'])) {
-            $dependencies = array_merge($dependencies, $extra['require-npm']);
+            $dependencies = $this->mergeNpmVersions($dependencies, $extra['require-npm']);
+        }
+
+        foreach ($mergedPackages as $dep) {
+            $packageExtra = $dep->getExtra();
+            if (isset($packageExtra['require-npm']) && count($packageExtra['require-npm'])) {
+                $dependencies = $this->mergeNpmVersions($dependencies, $packageExtra['require-npm']);
+            }
         }
 
         if ($dependencies) {
-            if ($path == '.' || (isset($extra['expose-npm-binaries']) && $extra['expose-npm-binaries'] == true)) {
-                $this->_installNpmDependencies($path, $dependencies);
+            $this->_installNpmDependencies($path, $dependencies);
+        }
+    }
+
+    /**
+     * Merges 2 version of arrays.
+     *
+     * @param array $array1
+     * @param array $array2
+     * @return array
+     */
+    private function mergeNpmVersions(array $array1, array $array2) {
+        foreach ($array2 as $package => $version) {
+            if (!isset($array1[$package])) {
+                $array1[$package] = $version;
+            } else {
+                if ($array1[$package] != $version) {
+                    $array1[$package] .= " ".$version;
+                }
             }
         }
+        return $array1;
     }
 
     private function _installNpmDependencies($path, $dependencies)
@@ -199,15 +234,17 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
         unlink('package.json');
 
+        chdir($prevCwd);
+    }
+
+    private function _createNpmBinaries() {
         // Let's link binaries, if any:
         $linkWriter = new LinkWriter($this->composer->getConfig()->get('bin-dir'));
-        
+
         $binaries = glob("node_modules/.bin/*");
         foreach ($binaries as $binary) {
             $linkWriter->writeLink($binary);
         }
-        
-        chdir($prevCwd);
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Some NPM packages provide binary files (for instance `gulp` and `grunt`).
 NPM binaries will be exposed in the `vendor/bin` directory if the NPM dependency is declared in the **root Composer 
 package**.
 
-If you are writing a package and want a NPM binary to be exposed in `vendor/bin`, you can add the `expose-npm-binaries`
-attribute to the composer `extra` session:
+If you are writing a package and want a NPM package to be available in the `node_modules` directory of Composer's root
+ (instead of the `node_modules` directory of your package), you can add the `expose-npm-packages`
+attribute to the composer `extra` session of your package:
  
      "require": {
          "koala-framework/composer-extra-assets": "~1.1"
@@ -50,6 +51,6 @@ attribute to the composer `extra` session:
          "require-npm": {
              "gulp": "*"
          },
-         "expose-npm-binaries": true
+         "expose-npm-packages": true
      }
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,29 @@ composer.json
             "qunit": "*"
         }
     }
+
+### Bower dependencies
+
+Bower dependencies will be installed in the `vendor/bower_components` directory.
+
+### NPM dependencies
+
+NPM dependencies will be installed in the `node_modules` directory of the package that requires the dependency.
+Some NPM packages provide binary files (for instance `gulp` and `grunt`).
+
+NPM binaries will be exposed in the `vendor/bin` directory if the NPM dependency is declared in the **root Composer 
+package**.
+
+If you are writing a package and want a NPM binary to be exposed in `vendor/bin`, you can add the `expose-npm-binaries`
+attribute to the composer `extra` session:
+ 
+     "require": {
+         "koala-framework/composer-extra-assets": "~1.1"
+     },
+     "extra": {
+         "require-npm": {
+             "gulp": "*"
+         },
+         "expose-npm-binaries": true
+     }
+

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "composer-plugin",
     "require": {
         "composer-plugin-api": "1.0.0",
-        "mouf/nodejs-installer": "~1.0",
+        "mouf/nodejs-installer": ">=1.0.2 <2.0",
         "version/version": "~2.0"
     },
     "require-dev": {
@@ -16,7 +16,7 @@
         "class": "Kwf\\ComposerExtraAssets\\Plugin",
         "mouf": {
             "nodejs": {
-                "version": ">=1.0.2 <2.0"
+                "version": ">=0.10"
             }
         },
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "class": "Kwf\\ComposerExtraAssets\\Plugin",
         "mouf": {
             "nodejs": {
-                "version": ">=0.10"
+                "version": ">=1.0.2 <2.0"
             }
         },
         "branch-alias": {


### PR DESCRIPTION
Hi @nsams ,

Following your comment on #7, here is a proposal to add the feature you suggested:
automatically detecting NPM binaries and creating a script in composer's binary directory to launch them.

I've tested with gulp on Windows and Linux, and it seems to work great :)

My composer.json test file:

```
{
      "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/moufmouf/composer-extra-assets"
        }
    ],
  "require": {
    "koala-framework/composer-extra-assets": "dev-master"
  },
  "extra": {
    "require-npm": {
      "gulp": "*"
    }
  },
  "minimum-stability": "dev"
}
```

Run gulp with: `vendor/bin/gulp`

A quick note about a detail in the implementation: I integrated in the `LinkWriter` class a piece of code from Symfony's FileSystem component (rather than adding a Composer dependency on Symfony's FileSystem). This is the function to find a relative path from an absolute path. I did this because I want `composer-extra-assets` to be compatible with any package (including future versions of Symfony, like Symfony 3, that might put different constraints on the symfony/filsesystem package).