### PR TITLE
Use CompletePackageInterface in test of package

### DIFF
--- a/Kwf/ComposerExtraAssets/Plugin.php
+++ b/Kwf/ComposerExtraAssets/Plugin.php
@@ -109,7 +109,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         );
         $packages = array_merge($packages, $this->composer->getRepositoryManager()->getLocalRepository()->getCanonicalPackages());
         foreach ($packages as $package){
-            if ($package instanceof \Composer\Package\CompletePackage) {
+            if ($package instanceof \Composer\Package\CompletePackageInterface) {
                 $extra = $package->getExtra();
                 if (isset($extra['require-bower'])) {
                     $requireBower = $this->_mergeDependencyVersions($requireBower, $extra['require-bower']);


### PR DESCRIPTION
In the resolution of bower dependecies, you merge rootPackages and the others packages (line 110) and test if package is an instance of CompletePackage.

 But in the case where the root package uses an alias :

``
    "branch-alias": {
      "dev-master": "2.0.x-dev"
    },
``
The type of package is [``RootAliasPackage``](https://getcomposer.org/apidoc/master/Composer/Package/RootAliasPackage.html) which not extend ``CompletePackage`` like ``RootPackage``.

So i think is better to check on an interface ``CompletePackageInterface`` to take all case